### PR TITLE
Make regex non greedy

### DIFF
--- a/RichTextResolver.cs
+++ b/RichTextResolver.cs
@@ -13,7 +13,7 @@ namespace LeeConlin.Kentico12.MVC.WidgetResolver
     {
         public IWidgetResolver WidgetResolver { get; }
         public IWidgetRegistry WidgetRegistry { get; }
-        private const string WIDGET_REGEX = @"\{\^widget\|(.+)\^\}";
+        private const string WIDGET_REGEX = @"\{\^widget\|(.+?)\^\}";
         private const string WIDGET_INTERNAL_REGEX = @"^\(([a-zA-Z0-9]+)\)(.+)$";
 
         public RichTextResolver(IWidgetResolver widgetResolver, IWidgetRegistry widgetRegistry)


### PR DESCRIPTION
The regex used to extract widgets is greedy: [regexr.com](https://regexr.com/4tla2)
If there are two widgets in one line, both get matched as one which results in a duplicate key exception while generating the JObject. A small change of the regex should do the trick.